### PR TITLE
Closes #161. Can't change to sub-total (this is used when shipping or…

### DIFF
--- a/website/apps/themebro/templates/shop/includes/order_totals.html
+++ b/website/apps/themebro/templates/shop/includes/order_totals.html
@@ -24,6 +24,8 @@
         {% endif %}
         </label> <span>{{ tax_total|currency }}</span>
     </div>
+    {% else %}
+    <div><label>+ TAX</label></div>
     {% endif %}
     <div class="total"><label>Total: </label> <span>{{ order_total|currency }}</span></div>
 </div>


### PR DESCRIPTION
… discounts are in place). I can add +Tax to the list when tax calculation isn't available. Found an easy way to do this just by modifying an existing template.