### PR TITLE
Fix time in admin console

### DIFF
--- a/website/settings/settings.py
+++ b/website/settings/settings.py
@@ -69,7 +69,7 @@ ALLOWED_HOSTS = [
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/Vancouver'
 
 # If you set this to True, Django will use timezone-aware datetimes.
 USE_TZ = True


### PR DESCRIPTION
Modified system timezone to 'America/Vancouver'. Confirmed database is still saving in UTC. Still need to test with PostgreSQL before migrating to prod.